### PR TITLE
Add LINKSWAP Adapter

### DIFF
--- a/contracts/adapters/linkswap/LinkswapAdapter.sol
+++ b/contracts/adapters/linkswap/LinkswapAdapter.sol
@@ -1,0 +1,41 @@
+// Copyright (C) 2020 Zerion Inc. <https://zerion.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.6.5;
+pragma experimental ABIEncoderV2;
+
+import { ERC20 } from "../../ERC20.sol";
+import { ProtocolAdapter } from "../ProtocolAdapter.sol";
+
+
+/**
+ * @title Adapter for LINKSWAP protocol.
+ * @dev Implementation of ProtocolAdapter interface.
+ * @author Giovanni Di Siena <giodisiena@gmail.com>
+ */
+contract LinkswapAdapter is ProtocolAdapter {
+
+    string public constant override adapterType = "Asset";
+
+    string public constant override tokenType = "Uniswap V2 pool token";
+
+    /**
+     * @return Amount of LINKSWAP LP tokens (LSLP) held by the given account.
+     * @dev Implementation of ProtocolAdapter interface function.
+     */
+    function getBalance(address token, address account) external view override returns (uint256) {
+        return ERC20(token).balanceOf(account);
+    }
+}

--- a/contracts/adapters/linkswap/LinkswapStakingAdapter.sol
+++ b/contracts/adapters/linkswap/LinkswapStakingAdapter.sol
@@ -1,0 +1,200 @@
+// Copyright (C) 2020 Zerion Inc. <https://zerion.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.6.5;
+pragma experimental ABIEncoderV2;
+
+import { ERC20 } from "../../ERC20.sol";
+import { ProtocolAdapter } from "../ProtocolAdapter.sol";
+
+
+/**
+ * @dev StakingRewards contract interface.
+ * Only the functions required for LinkswapStakingAdapter contract are added.
+ * The StakingRewards contract is available here
+ * github.com/yflink/linkswap-staking/blob/master/contracts/StakingRewards.sol.
+ */
+interface StakingRewards {
+    function earned(address) external view returns (uint256);
+}
+
+
+/**
+ * @title Adapter for LINKSWAP governance and LP rewards staking.
+ * @dev Implementation of ProtocolAdapter interface.
+ * @author Giovanni Di Siena <giodisiena@gmail.com>
+ */
+contract LinkswapStakingAdapter is ProtocolAdapter {
+
+    string public constant override adapterType = "Asset";
+
+    string public constant override tokenType = "ERC20";
+
+    address internal constant YFL = 0x28cb7e841ee97947a86B06fA4090C8451f64c0be;
+    address internal constant WETH = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2;
+    address internal constant LINK = 0x514910771af9ca656af840dff83e8264ecf986ca;
+    address internal constant BUSD = 0x4fabb145d64652a948d72533023f6e7a623c7c53;
+    address internal constant USDC = 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48;
+    address internal constant USDT = 0xdac17f958d2ee523a2206206994597c13d831ec7;
+    address internal constant CFI = 0x63b4f3e3fa4e438698ce330e365e831f7ccd1ef4;
+    address internal constant MASQ = 0x06F3C323f0238c72BF35011071f2b5B7F43A054c;
+    address internal constant DPI = 0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b;
+    address internal constant CEL = 0xaaaebe6fe48e54f431b0c390cfaf0b017d09d42d;
+    address internal constant YAX = 0xb1dc9124c395c1e97773ab855d66e879f053a289;
+    address internal constant GSWAP = 0xaac41EC512808d64625576EDdd580e7Ea40ef8B2;
+    address internal constant AZUKI = 0x910524678C0B1B23FFB9285a81f99C29C11CBaEd;
+    address internal constant DOKI = 0x9ceb84f92a0561fa3cc4132ab9c0b76a59787544;
+
+    address internal constant LSLP_YFL_WETH = 0x7e5A536F3d79791E283940ec379CEE10C9C40e86;
+    address internal constant LSLP_YFL_LINK = 0x189a730921550314934019d184ec05726881d481;
+    address internal constant LSLP_DPI_LINK = 0x017fad4b7a54c1ace95ca614954e4d0d12cdb27e;
+    address internal constant LSLP_LINK_GSWAP = 0xdef0cef53e0d4c6a5e568c53edcf45ceb33dbe46;
+    address internal constant LSLP_LINK_CEL = 0x639916bb4b29859fadf7a272185a3212157f8ce1;
+    address internal constant LSLP_MASQ_WETH = 0x37cee65899da4b1738412814155540c98dfd752c;
+    address internal constant LSLP_BUSD_LINK = 0x983c9a1bcf0eb980a232d1b17bffd6bbf68fe4ce;
+    address internal constant LSLP_LINK_YAX = 0x626b88542495d2e341d285969f8678b99cd91da7;
+    address internal constant LSLP_LINK_CFI = 0xf68c01198cddeafb9d2ea43368fc9fa509a339fa;
+    address internal constant LSLP_LINK_USDC = 0x9d996bDD1F65C835EE92Cd0b94E15d886EF14D63;
+    address internal constant LSLP_LINK_USDT = 0xf36c9fc3c2abe4132019444aff914fc8dc9785a9;
+    address internal constant LSLP_LINK_AZUKI = 0xB7Cd446a2a80d4770C6bECde661B659cFC55acf5;
+    address internal constant LSLP_LINK_DOKI = 0xbe755C548D585dbc4e3Fe4bcD712a32Fd81e5Ba0;
+
+    address internal constant LSLP_YFL_WETH_POOL = 0x72368fB97dab2B94A5664EbeEbF504EF482fF149;
+    address internal constant LSLP_YFL_LINK_POOL = 0x35fc734948b36370c15387342f048ac87210bc22;
+    address internal constant LSLP_DPI_LINK_POOL = 0xfe04c284a9725c141cf6de85d7e8452af1b48ab7;
+    address internal constant LSLP_LINK_GSWAP_POOL = 0x4e33d27cbcce9fe1c4a21a0f7c8b31c9cf5c0b75;
+    address internal constant LSLP_LINK_CEL_POOL = 0xfa9712ccc86c6bd52187125dca4c2b9c7baa3ef8;
+    address internal constant LSLP_MASQ_WETH_POOL = 0x790adfe75706cf70191b2bd729048e42d8ed9f60;
+    address internal constant LSLP_BUSD_LINK_POOL = 0x997d4babf8290a19ecdcbd10058fc438eb6f30de;
+    address internal constant LSLP_LINK_YAX_POOL = 0x603065b7e2f69c897f154ca429a2b96cf4703f56;
+    address internal constant LSLP_LINK_CFI_POOL = 0x5662e09d064781cf2e98732ec3fc7a4a4ab67ea5;
+    address internal constant LSLP_LINK_USDC_POOL = 0x0d03cff17367478c3349a579e50259d8a793bbc8;
+    address internal constant LSLP_LINK_USDT_POOL = 0x603065b7e2f69c897f154ca429a2b96cf4703f56;
+    address internal constant LSLP_LINK_AZUKI_POOL = 0xa74Ef3faB9E94578c79e0077f6Bd572C9efc8733;
+    address internal constant LSLP_LINK_DOKI_POOL = 0x795BD26b99082E59478cfe8d9Cd207bb196808E4;
+
+    address internal constant GOVERNANCE = 0x75D1aA733920b14fC74c9F6e6faB7ac1EcE8482E;
+    address internal constant GOVERNANCE_FEES = 0x0389d755C1833C9b350d4E8B619Eae16deFc1CbA;
+
+    /**
+     * @return Amount of staked tokens / rewards earned after staking for a given account.
+     * @dev Implementation of ProtocolAdapter interface function.
+     */
+    function getBalance(address token, address account) external view override returns (uint256) {
+        if (token == YFL) {
+            uint256 totalRewards = 0;
+
+            totalRewards += ERC20(GOVERNANCE).balanceOf(account);
+            
+            totalRewards += StakingRewards(LSLP_YFL_LINK_POOL).earned(account,0);
+            totalRewards += StakingRewards(LSLP_YFL_WETH_POOL).earned(account,0);
+            totalRewards += StakingRewards(LSLP_DPI_LINK_POOL).earned(account,0);
+            totalRewards += StakingRewards(LSLP_MASQ_WETH_POOL).earned(account,0);
+            totalRewards += StakingRewards(LSLP_BUSD_LINK_POOL).earned(account,0);
+            totalRewards += StakingRewards(LSLP_LINK_GSWAP_POOL).earned(account,0);
+            totalRewards += StakingRewards(LSLP_LINK_CEL_POOL).earned(account,0);
+            totalRewards += StakingRewards(LSLP_LINK_YAX_POOL).earned(account,0);
+            totalRewards += StakingRewards(LSLP_LINK_CFI_POOL).earned(account,0);
+            totalRewards += StakingRewards(LSLP_LINK_USDC_POOL).earned(account,0);
+            totalRewards += StakingRewards(LSLP_LINK_USDT_POOL).earned(account,0);
+
+            return totalRewards;
+        } else if (token == CFI) {
+            return StakingRewards(LSLP_LINK_CFI_POOL).earned(account,1);
+        } else if (token == MASQ) {
+            return StakingRewards(LSLP_MASQ_WETH_POOL).earned(account,1);
+        } else if (token == DPI) {
+            return StakingRewards(LSLP_DPI_LINK_POOL).earned(account,1);
+        } else if (token == CEL) {
+            return StakingRewards(LSLP_LINK_CEL_POOL).earned(account,1);
+        } else if (token == YAX) {
+            return StakingRewards(LSLP_LINK_YAX_POOL).earned(account,1);
+        } else if (token == GSWAP) {
+            return StakingRewards(LSLP_LINK_GSWAP_POOL).earned(account,1);
+        } else if (token == AZUKI) {
+            uint256 totalRewards = 0;
+            totalRewards += StakingRewards(LSLP_LINK_AZUKI_POOL).earned(account,1);
+            totalRewards += StakingRewards(LSLP_LINK_DOKI_POOL).earned(account,1);
+            return totalRewards;
+        } else if (token == LSLP_YFL_WETH) {
+            uint256 total = 0;
+            total += ERC20(LSLP_YFL_WETH_POOL).balanceOf(account);
+            total += ERC20(LSLP_YFL_WETH).balanceOf(GOVERNANCE_FEES);
+            return total
+        } else if (token == LSLP_YFL_LINK) {
+            uint256 total = 0;
+            total += ERC20(LSLP_YFL_LINK_POOL).balanceOf(account);
+            total += ERC20(LSLP_YFL_LINK).balanceOf(GOVERNANCE_FEES);
+            return total
+        } else if (token == LSLP_DPI_LINK) {
+            uint256 total = 0;
+            total += ERC20(LSLP_DPI_LINK_POOL).balanceOf(account);
+            total += ERC20(LSLP_DPI_LINK).balanceOf(GOVERNANCE_FEES);
+            return total
+        } else if (token == LSLP_MASQ_WETH) {
+            uint256 total = 0;
+            total += ERC20(LSLP_MASQ_WETH_POOL).balanceOf(account);
+            total += ERC20(LSLP_MASQ_WETH).balanceOf(GOVERNANCE_FEES);
+            return total
+        } else if (token == LSLP_BUSD_LINK) {
+            uint256 total = 0;
+            total += ERC20(LSLP_BUSD_LINK_POOL).balanceOf(account);
+            total += ERC20(LSLP_BUSD_LINK).balanceOf(GOVERNANCE_FEES);
+            return total
+        } else if (token == LSLP_LINK_GSWAP) {
+            uint256 total = 0;
+            total += ERC20(LSLP_LINK_GSWAP_POOL).balanceOf(account);
+            total += ERC20(LSLP_LINK_GSWAP).balanceOf(GOVERNANCE_FEES);
+            return total
+        } else if (token == LSLP_LINK_CFI) {
+            uint256 total = 0;
+            total += ERC20(LSLP_LINK_CFI_POOL).balanceOf(account);
+            total += ERC20(LSLP_LINK_CFI).balanceOf(GOVERNANCE_FEES);
+            return total
+        } else if (token == LSLP_LINK_CEL) {
+            uint256 total = 0;
+            total += ERC20(LSLP_LINK_CEL_POOL).balanceOf(account);
+            total += ERC20(LSLP_LINK_CEL).balanceOf(GOVERNANCE_FEES);
+            return total
+        } else if (token == LSLP_LINK_YAX) {
+            uint256 total = 0;
+            total += ERC20(LSLP_LINK_YAX_POOL).balanceOf(account);
+            total += ERC20(LSLP_LINK_YAX).balanceOf(GOVERNANCE_FEES);
+            return total
+        } else if (token == LSLP_LINK_USDC) {
+            uint256 total = 0;
+            total += ERC20(LSLP_LINK_USDC_POOL).balanceOf(account);
+            total += ERC20(LSLP_LINK_USDC).balanceOf(GOVERNANCE_FEES);
+            return total
+        } else if (token == LSLP_LINK_USDT) {
+            uint256 total = 0;
+            total += ERC20(LSLP_LINK_USDT_POOL).balanceOf(account);
+            total += ERC20(LSLP_LINK_USDT).balanceOf(GOVERNANCE_FEES);
+            return total
+        } else if (token == LSLP_LINK_AZUKI) {
+            uint256 total = 0;
+            total += ERC20(LSLP_LINK_AZUKI_POOL).balanceOf(account);
+            total += ERC20(LSLP_LINK_AZUKI).balanceOf(GOVERNANCE_FEES);
+            return total
+        } else if (token == LSLP_LINK_DOKI) {
+            uint256 total = 0;
+            total += ERC20(LSLP_LINK_DOKI_POOL).balanceOf(account);
+            total += ERC20(LSLP_LINK_DOKI).balanceOf(GOVERNANCE_FEES);
+            return total
+        } else {
+            return 0;
+        }
+    }
+}

--- a/migrations_scripts/1_deploy_registry_and_add_adapters.js
+++ b/migrations_scripts/1_deploy_registry_and_add_adapters.js
@@ -33,6 +33,8 @@ const IearnAdapter = artifacts.require('IearnAdapter');
 const KeeperDaoAssetAdapter = artifacts.require('KeeperDaoAssetAdapter');
 const KimchiStakingAdapter = artifacts.require('KimchiStakingAdapter');
 const KyberAdapter = artifacts.require('KyberAdapter');
+const LinkswapAdapter = artifacs.require('LinkswapAdapter');
+const LinkswapStakingAdapter = artifacs.require('LinkswapStakingAdapter');
 const LivepeerStakingAdapter = artifacts.require('LivepeerStakingAdapter');
 const ChaiAdapter = artifacts.require('ChaiAdapter');
 const DSRAdapter = artifacts.require('DSRAdapter');
@@ -78,6 +80,7 @@ const DodoTokenAdapter = artifacts.require('DodoTokenAdapter');
 const IdleTokenAdapter = artifacts.require('IdleTokenAdapter');
 const IearnTokenAdapter = artifacts.require('IearnTokenAdapter');
 const KeeperDaoTokenAdapter = artifacts.require('IearnTokenAdapter');
+const LinkswapTokenAdapter = artifacs.require('LinkswapTokenAdapter');
 const ChaiTokenAdapter = artifacts.require('ChaiTokenAdapter');
 const MelonTokenAdapter = artifacts.require('MelonTokenAdapter');
 const MstableTokenAdapter = artifacts.require('MstableTokenAdapter');
@@ -263,6 +266,28 @@ const usdcPoolAddress = '0x0034Ea9808E620A0EF79261c51AF20614B742B24';
 const yfiAddress = '0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e';
 const balancerDai98Yfi2Address = '0x60626db611a9957C1ae4Ac5b7eDE69e24A3B76c5';
 const balancerYfi2yCrv98Address = '0x95C4B6C7CfF608c0CA048df8b81a484aA377172B';
+
+const yflAddress = '0x28cb7e841ee97947a86B06fA4090C8451f64c0be';
+const cfiAddress = '0x63b4f3e3fa4e438698ce330e365e831f7ccd1ef4';
+const masqAddress = '0x06F3C323f0238c72BF35011071f2b5B7F43A054c';
+const dpiAddress = '0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b';
+const celAddress = '0xaaaebe6fe48e54f431b0c390cfaf0b017d09d42d';
+const yaxAddress = '0xb1dc9124c395c1e97773ab855d66e879f053a289';
+const gswapAddress = '0xaac41EC512808d64625576EDdd580e7Ea40ef8B2';
+
+const lslpYflLink = '0x189a730921550314934019d184ec05726881d481';
+const lslpDpiLink = '0x017fad4b7a54c1ace95ca614954e4d0d12cdb27e';
+const lslpLinkGswap = '0xdef0cef53e0d4c6a5e568c53edcf45ceb33dbe46';
+const lslpLinkCel = '0x639916bb4b29859fadf7a272185a3212157f8ce1';
+const lslpMasqWeth = '0x37cee65899da4b1738412814155540c98dfd752c';
+const lslpBusdLink = '0x983c9a1bcf0eb980a232d1b17bffd6bbf68fe4ce';
+const lslpLinkYax = '0x626b88542495d2e341d285969f8678b99cd91da7';
+const lslpLinkCfi = '0xf68c01198cddeafb9d2ea43368fc9fa509a339fa';
+const lslpLinkUsdc = '0x9d996bDD1F65C835EE92Cd0b94E15d886EF14D63';
+const lslpLinkUsdt = '0xf36c9fc3c2abe4132019444aff914fc8dc9785a9';
+const lslpYflWeth = '0x7e5A536F3d79791E283940ec379CEE10C9C40e86';
+const lslpLinkAzuki = '0xB7Cd446a2a80d4770C6bECde661B659cFC55acf5';
+const lslpLinkDoki = '0xbe755C548D585dbc4e3Fe4bcD712a32Fd81e5Ba0';
 
 const chaiAddress = '0x06AF07097C9Eeb7fD685c692751D5C66dB49c215';
 
@@ -847,6 +872,33 @@ const yearnStakingV2AdapterTokens = [
   yfiAddress,
   yCrvAddress,
 ];
+const LinkswapStakingAdapterTokens = [
+  yflAddress,
+  wethAddress,
+  linkAddress,
+  busdAddress,
+  usdcAddress,
+  usdtAddress,
+  cfiAddress,
+  masqAddress,
+  dpiAddress,
+  celAddress,
+  yaxAddress,
+  gswapAddress,
+  lslpYflWeth,
+  lslpYflLink,
+  lslpBusdLink,
+  lslpLinkUsdc,
+  lslpLinkUsdt,
+  lslpLinkCfi,
+  lslpMasqWeth,
+  lslpDpiLink,
+  lslpLinkCel,
+  lslpLinkYax,
+  lslpLinkGswap,
+  lslpLinkAzuki,
+  lslpLinkDoki,
+];
 const zrxAdapterTokens = [
   zrxAddress,
 ];
@@ -1123,6 +1175,21 @@ module.exports = async (deployer, network, accounts) => {
     'Yield aggregator for lending platforms',
     'iearn.finance',
     'protocol-icons.s3.amazonaws.com/iearn.png',
+    '0',
+  ]);
+
+  await deployer.deploy(LinkswapAdapter, { from: accounts[0] });
+  await deployer.deploy(LinkswapStakingAdapter, { from: accounts[0] });
+  adapters.push(
+    [LinkswapAdapter.address, LinkswapStakingAdapter.address],
+  );
+  tokens.push([LinkswapStakingAdapterTokens]);
+  protocolNames.push('LINKSWAP');
+  metadata.push([
+    'LINKSWAP',
+    'YF Link community-governed automated market maker',
+    'linkswap.app',
+    'protocol-icons.s3.amazonaws.com/yflink.png',
     '0',
   ]);
 
@@ -1586,6 +1653,12 @@ module.exports = async (deployer, network, accounts) => {
     .then(() => {
       tokenAdapters.push(
         UniswapV2TokenAdapter.address,
+      );
+    });
+  await deployer.deploy(LinkswapTokenAdapter, { from: accounts[0] })
+    .then(() => {
+      tokenAdapters.push(
+        LinkswapTokenAdapter.address,
       );
     });
   await deployer.deploy(AdapterRegistry, { from: accounts[0] })

--- a/test/LinkswapAdapter.js
+++ b/test/LinkswapAdapter.js
@@ -1,0 +1,378 @@
+import displayToken from './helpers/displayToken';
+
+const AdapterRegistry = artifacts.require('AdapterRegistry');
+const ProtocolAdapter = artifacts.require('LinkswapAdapter');
+const TokenAdapter = artifacts.require('LinkswapTokenAdapter');
+const ERC20TokenAdapter = artifacts.require('ERC20TokenAdapter');
+
+contract.only('LinkswapAdapter', () => {
+  const yflAddress = '0x28cb7e841ee97947a86B06fA4090C8451f64c0be';
+  const wethAddress = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+  const linkAddress = '0x514910771AF9Ca656af840dff83E8264EcF986CA';
+  const usdtAddress = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
+  const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+  const busdAddress = '0x4Fabb145d64652a948d72533023f6E7A623C7C53';
+  const cfiAddress = '0x63b4f3e3fa4e438698ce330e365e831f7ccd1ef4';
+  const masqAddress = '0x06F3C323f0238c72BF35011071f2b5B7F43A054c';
+  const dpiAddress = '0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b';
+  const celAddress = '0xaaaebe6fe48e54f431b0c390cfaf0b017d09d42d';
+  const yaxAddress = '0xb1dc9124c395c1e97773ab855d66e879f053a289';
+  const gswapAddress = '0xaac41EC512808d64625576EDdd580e7Ea40ef8B2';
+  const azukiAddress = '0x910524678C0B1B23FFB9285a81f99C29C11CBaEd';
+  const dokiAddress = '0x9ceb84f92a0561fa3cc4132ab9c0b76a59787544';
+
+  const lslpYflLink = '0x189a730921550314934019d184ec05726881d481';
+  const lslpDpiLink = '0x017fad4b7a54c1ace95ca614954e4d0d12cdb27e';
+  const lslpLinkGswap = '0xdef0cef53e0d4c6a5e568c53edcf45ceb33dbe46';
+  const lslpLinkCel = '0x639916bb4b29859fadf7a272185a3212157f8ce1';
+  const lslpMasqWeth = '0x37cee65899da4b1738412814155540c98dfd752c';
+  const lslpBusdLink = '0x983c9a1bcf0eb980a232d1b17bffd6bbf68fe4ce';
+  const lslpLinkYax = '0x626b88542495d2e341d285969f8678b99cd91da7';
+  const lslpLinkCfi = '0xf68c01198cddeafb9d2ea43368fc9fa509a339fa';
+  const lslpLinkUsdc = '0x9d996bDD1F65C835EE92Cd0b94E15d886EF14D63';
+  const lslpLinkUsdt = '0xf36c9fc3c2abe4132019444aff914fc8dc9785a9';
+  const lslpYflWeth = '0x7e5A536F3d79791E283940ec379CEE10C9C40e86';
+  const lslpLinkAzuki = '0xB7Cd446a2a80d4770C6bECde661B659cFC55acf5';
+  const lslpLinkDoki = '0xbe755C548D585dbc4e3Fe4bcD712a32Fd81e5Ba0';
+
+  const testAddress = '0x42b9dF65B219B3dD36FF330A4dD8f327A6Ada990';
+
+  let accounts;
+  let adapterRegistry;
+  let protocolAdapterAddress;
+  let tokenAdapterAddress;
+  let erc20TokenAdapterAddress;
+  const yflLink = [
+    lslpYflLink,
+    'YFL-LINK',
+    'LSLP',
+    '18',
+  ];
+  const dpiLink = [
+    lslpDpiLink,
+    'DPI-LINK',
+    'LSLP',
+    '18',
+  ];
+  const linkGswap = [
+    lslpLinkGswap,
+    'LINK-GSWAP',
+    'LSLP',
+    '18',
+  ];
+  const linkCel = [
+    lslpLinkCel,
+    'LINK-CEL',
+    'LSLP',
+    '18',
+  ];
+  const masqWeth = [
+    lslpMasqWeth,
+    'MASQ-WETH',
+    'LSLP',
+    '18',
+  ];
+  const busdLink = [
+    lslpBusdLink,
+    'BUSD-LINK',
+    'LSLP',
+    '18',
+  ];
+  const linkYax = [
+    lslpLinkYax,
+    'LINK-YAX',
+    'LSLP',
+    '18',
+  ];
+  const linkCfi = [
+    lslpLinkCfi,
+    'LINK-CFI',
+    'LSLP',
+    '18',
+  ];
+  const linkUsdc = [
+    lslpLinkUsdc,
+    'LINK-USDC',
+    'LSLP',
+    '18',
+  ];
+  const linkUsdt = [
+    lslpLinkUsdt,
+    'LINK-USDT',
+    'LSLP',
+    '18',
+  ];
+  const linkAzuki = [
+    lslpLinkAzuki,
+    'LINK-AZUKI',
+    'LSLP',
+    '18',
+  ];
+  const linkDoki = [
+    lslpLinkDoki,
+    'LINK-DOKI',
+    'LSLP',
+    '18',
+  ];
+  const yflWeth = [
+    lslpYflWeth,
+    'YFL-WETH',
+    'LSLP',
+    '18',
+  ];
+  const yfl = [
+    yflAddress,
+    'YF Link',
+    'YFL',
+    '18',
+  ];
+  const weth = [
+    wethAddress,
+    'Wrapped Ether',
+    'WETH',
+    '18',
+  ];
+  const link = [
+    linkAddress,
+    'ChainLink Token',
+    'LINK',
+    '18',
+  ];
+  const usdc = [
+    usdcAddress,
+    'USD Coin',
+    'USDC',
+    '6',
+  ];
+  const usdt = [
+    usdtAddress,
+    'Tether USD',
+    'USDT',
+    '6',
+  ];
+  const busd = [
+    busdAddress,
+    'Binance USD',
+    'BUSD',
+    '18',
+  ];
+  const cfi = [
+    cfiAddress,
+    'CyberFi Token',
+    'CFI',
+    '18',
+  ];
+  const masq = [
+    masqAddress,
+    'MASQ',
+    'MASQ',
+    '18',
+  ];
+  const dpi = [
+    dpiAddress,
+    'DefiPulse Index',
+    'DPI',
+    '18',
+  ];
+  const cel = [
+    celAddress,
+    'Celsius',
+    'CEL',
+    '4',
+  ];
+  const yax = [
+    yaxAddress,
+    'yAxis',
+    'YAX',
+    '18',
+  ];
+  const gswap = [
+    gswapAddress,
+    'gameswap.org',
+    'GSWAP',
+    '18',
+  ];
+  const azuki = [
+    azukiAddress,
+    'DokiDokiAzuki',
+    'AZUKI',
+    '18',
+  ];
+  const doki = [
+    dokiAddress,
+    'DokiDokiFinance',
+    'DOKI',
+    '18',
+  ];
+  const yflLinkNa = [
+    lslpYflLink,
+    'Not available',
+    'N/A',
+    '0',
+  ];
+
+  beforeEach(async () => {
+    accounts = await web3.eth.getAccounts();
+    await ProtocolAdapter.new({ from: accounts[0] })
+      .then((result) => {
+        protocolAdapterAddress = result.address;
+      });
+    await TokenAdapter.new({ from: accounts[0] })
+      .then((result) => {
+        tokenAdapterAddress = result.address;
+      });
+    await ERC20TokenAdapter.new({ from: accounts[0] })
+      .then((result) => {
+        erc20TokenAdapterAddress = result.address;
+      });
+    await AdapterRegistry.new({ from: accounts[0] })
+      .then((result) => {
+        adapterRegistry = result.contract;
+      });
+    await adapterRegistry.methods.addProtocols(
+      ['LINKSWAP'],
+      [[
+        'Mock Protocol Name',
+        'Mock protocol description',
+        'Mock website',
+        'Mock icon',
+        '0',
+      ]],
+      [[
+        protocolAdapterAddress,
+      ]],
+      [[[
+        lslpYflLink,
+        lslpYflWeth,
+        lslpLinkUsdc,
+        lslpLinkUsdt,
+        lslpLinkCel,
+        lslpLinkYax,
+        lslpLinkCfi,
+        lslpLinkGswap,
+        lslpBusdLink,
+        lslpDpiLink,
+        lslpMasqWeth,
+        lslpLinkAzuki,
+        lslpLinkDoki,
+      ]]],
+    )
+      .send({
+        from: accounts[0],
+        gas: '1000000',
+      });
+    await adapterRegistry.methods.addTokenAdapters(
+      ['ERC20', 'Uniswap V2 pool token'],
+      [erc20TokenAdapterAddress, tokenAdapterAddress],
+    )
+      .send({
+        from: accounts[0],
+        gas: '1000000',
+      });
+  });
+
+  it('should return correct balances', async () => {
+    await adapterRegistry.methods['getBalances(address)'](testAddress)
+      .call()
+      .then((result) => {
+        displayToken(result[0].adapterBalances[0].balances[0].base);
+        displayToken(result[0].adapterBalances[0].balances[0].underlying[0]);
+        displayToken(result[0].adapterBalances[0].balances[0].underlying[1]);
+        displayToken(result[0].adapterBalances[0].balances[1].base);
+        displayToken(result[0].adapterBalances[0].balances[1].underlying[0]);
+        displayToken(result[0].adapterBalances[0].balances[1].underlying[1]);
+        displayToken(result[0].adapterBalances[0].balances[2].base);
+        displayToken(result[0].adapterBalances[0].balances[2].underlying[0]);
+        displayToken(result[0].adapterBalances[0].balances[2].underlying[1]);
+        displayToken(result[0].adapterBalances[0].balances[3].base);
+        displayToken(result[0].adapterBalances[0].balances[3].underlying[0]);
+        displayToken(result[0].adapterBalances[0].balances[3].underlying[1]);
+        displayToken(result[0].adapterBalances[0].balances[4].base);
+        displayToken(result[0].adapterBalances[0].balances[4].underlying[0]);
+        displayToken(result[0].adapterBalances[0].balances[4].underlying[1]);
+        displayToken(result[0].adapterBalances[0].balances[5].base);
+        displayToken(result[0].adapterBalances[0].balances[5].underlying[0]);
+        displayToken(result[0].adapterBalances[0].balances[5].underlying[1]);
+        displayToken(result[0].adapterBalances[0].balances[6].base);
+        displayToken(result[0].adapterBalances[0].balances[6].underlying[0]);
+        displayToken(result[0].adapterBalances[0].balances[6].underlying[1]);
+        displayToken(result[0].adapterBalances[0].balances[7].base);
+        displayToken(result[0].adapterBalances[0].balances[7].underlying[0]);
+        displayToken(result[0].adapterBalances[0].balances[7].underlying[1]);
+        displayToken(result[0].adapterBalances[0].balances[8].base);
+        displayToken(result[0].adapterBalances[0].balances[8].underlying[0]);
+        displayToken(result[0].adapterBalances[0].balances[8].underlying[1]);
+        displayToken(result[0].adapterBalances[0].balances[9].base);
+        displayToken(result[0].adapterBalances[0].balances[9].underlying[0]);
+        displayToken(result[0].adapterBalances[0].balances[9].underlying[1]);
+        displayToken(result[0].adapterBalances[0].balances[10].base);
+        displayToken(result[0].adapterBalances[0].balances[10].underlying[0]);
+        displayToken(result[0].adapterBalances[0].balances[10].underlying[1]);
+        displayToken(result[0].adapterBalances[0].balances[11].base);
+        displayToken(result[0].adapterBalances[0].balances[11].underlying[0]);
+        displayToken(result[0].adapterBalances[0].balances[11].underlying[1]);
+        displayToken(result[0].adapterBalances[0].balances[12].base);
+        displayToken(result[0].adapterBalances[0].balances[12].underlying[0]);
+        displayToken(result[0].adapterBalances[0].balances[12].underlying[1]);
+        assert.deepEqual(result[0].adapterBalances[0].balances[0].underlying[0].metadata, yfl);
+        assert.deepEqual(result[0].adapterBalances[0].balances[1].underlying[0].metadata, yfl);
+        assert.deepEqual(result[0].adapterBalances[0].balances[2].underlying[0].metadata, link);
+        assert.deepEqual(result[0].adapterBalances[0].balances[3].underlying[0].metadata, link);
+        assert.deepEqual(result[0].adapterBalances[0].balances[4].underlying[0].metadata, link);
+        assert.deepEqual(result[0].adapterBalances[0].balances[5].underlying[0].metadata, link);
+        assert.deepEqual(result[0].adapterBalances[0].balances[6].underlying[0].metadata, link);
+        assert.deepEqual(result[0].adapterBalances[0].balances[7].underlying[0].metadata, link);
+        assert.deepEqual(result[0].adapterBalances[0].balances[8].underlying[0].metadata, busd);
+        assert.deepEqual(result[0].adapterBalances[0].balances[9].underlying[0].metadata, dpi);
+        assert.deepEqual(result[0].adapterBalances[0].balances[10].underlying[0].metadata, masq);
+        assert.deepEqual(result[0].adapterBalances[0].balances[11].underlying[0].metadata, link);
+        assert.deepEqual(result[0].adapterBalances[0].balances[12].underlying[0].metadata, link);
+        assert.deepEqual(result[0].adapterBalances[0].balances[0].base.metadata, yflLink);
+        assert.deepEqual(result[0].adapterBalances[0].balances[1].base.metadata, yflWeth);
+        assert.deepEqual(result[0].adapterBalances[0].balances[2].base.metadata, linkUsdc);
+        assert.deepEqual(result[0].adapterBalances[0].balances[3].base.metadata, linkUsdt);
+        assert.deepEqual(result[0].adapterBalances[0].balances[4].base.metadata, linkCel);
+        assert.deepEqual(result[0].adapterBalances[0].balances[5].base.metadata, linkYax);
+        assert.deepEqual(result[0].adapterBalances[0].balances[6].base.metadata, linkCfi);
+        assert.deepEqual(result[0].adapterBalances[0].balances[7].base.metadata, linkGswap);
+        assert.deepEqual(result[0].adapterBalances[0].balances[8].base.metadata, busdLink);
+        assert.deepEqual(result[0].adapterBalances[0].balances[9].base.metadata, dpiLink);
+        assert.deepEqual(result[0].adapterBalances[0].balances[10].base.metadata, masqWeth);
+        assert.deepEqual(result[0].adapterBalances[0].balances[11].base.metadata, linkAzuki);
+        assert.deepEqual(result[0].adapterBalances[0].balances[12].base.metadata, linkDoki);
+        assert.deepEqual(result[0].adapterBalances[0].balances[0].underlying[1].metadata, link);
+        assert.deepEqual(result[0].adapterBalances[0].balances[1].underlying[1].metadata, weth);
+        assert.deepEqual(result[0].adapterBalances[0].balances[2].underlying[1].metadata, usdc);
+        assert.deepEqual(result[0].adapterBalances[0].balances[3].underlying[1].metadata, usdt);
+        assert.deepEqual(result[0].adapterBalances[0].balances[4].underlying[1].metadata, cel);
+        assert.deepEqual(result[0].adapterBalances[0].balances[5].underlying[1].metadata, yax);
+        assert.deepEqual(result[0].adapterBalances[0].balances[6].underlying[1].metadata, cfi);
+        assert.deepEqual(result[0].adapterBalances[0].balances[7].underlying[1].metadata, gswap);
+        assert.deepEqual(result[0].adapterBalances[0].balances[8].underlying[1].metadata, link);
+        assert.deepEqual(result[0].adapterBalances[0].balances[9].underlying[1].metadata, link);
+        assert.deepEqual(result[0].adapterBalances[0].balances[10].underlying[1].metadata, weth);
+        assert.deepEqual(result[0].adapterBalances[0].balances[11].underlying[1].metadata, azuki);
+        assert.deepEqual(result[0].adapterBalances[0].balances[12].underlying[1].metadata, doki);
+      });
+  });
+
+  it('should not fail if token adapter is missing', async () => {
+    await adapterRegistry.methods.removeTokenAdapters(
+      ['LSLP'],
+    )
+      .send({
+        from: accounts[0],
+        gas: '1000000',
+      });
+    await adapterRegistry.methods.getAdapterBalance(
+      testAddress,
+      protocolAdapterAddress,
+      [lslpYflLink],
+    )
+      .call()
+      .then((result) => {
+        assert.deepEqual(result.balances[0].base.metadata, yflLinkNa);
+        assert.equal(result.balances[0].underlying.length, 0);
+      });
+  });
+});

--- a/test/LinkswapStakingAdapter.js
+++ b/test/LinkswapStakingAdapter.js
@@ -1,0 +1,76 @@
+import displayToken from './helpers/displayToken';
+
+const AdapterRegistry = artifacts.require('AdapterRegistry');
+const ProtocolAdapter = artifacts.require('LinkswapStakingAdapter');
+const ERC20TokenAdapter = artifacts.require('ERC20TokenAdapter');
+
+contract.only('LinkswapStakingAdapter', () => {
+  const yflAddress = '0x28cb7e841ee97947a86B06fA4090C8451f64c0be';
+  // Random address with positive balances
+  const testAddress = '0x42b9dF65B219B3dD36FF330A4dD8f327A6Ada990';
+
+  let accounts;
+  let adapterRegistry;
+  let protocolAdapterAddress;
+  let erc20TokenAdapterAddress;
+  const yfl = [
+    yflAddress,
+    'YF Link',
+    'YFL',
+    '18',
+  ];
+
+  beforeEach(async () => {
+    accounts = await web3.eth.getAccounts();
+    await ProtocolAdapter.new({ from: accounts[0] })
+      .then((result) => {
+        protocolAdapterAddress = result.address;
+      });
+    await ERC20TokenAdapter.new({ from: accounts[0] })
+      .then((result) => {
+        erc20TokenAdapterAddress = result.address;
+      });
+    await AdapterRegistry.new({ from: accounts[0] })
+      .then((result) => {
+        adapterRegistry = result.contract;
+      });
+    await adapterRegistry.methods.addProtocols(
+      ['LINKSWAP Staking'],
+      [[
+        'Mock Protocol Name',
+        'Mock protocol description',
+        'Mock website',
+        'Mock icon',
+        '0',
+      ]],
+      [[
+        protocolAdapterAddress,
+      ]],
+      [[[
+        yflAddress,
+      ]]],
+    )
+      .send({
+        from: accounts[0],
+        gas: '1000000',
+      });
+    await adapterRegistry.methods.addTokenAdapters(
+      ['ERC20'],
+      [erc20TokenAdapterAddress],
+    )
+      .send({
+        from: accounts[0],
+        gas: '1000000',
+      });
+  });
+
+  it('should return correct balances', async () => {
+    await adapterRegistry.methods['getBalances(address)'](testAddress)
+      .call()
+      .then((result) => {
+        displayToken(result[0].adapterBalances[0].balances[0].base);
+        displayToken(result[0].adapterBalances[0].balances[1].base);
+        assert.deepEqual(result[0].adapterBalances[0].balances[0].base.metadata, yfl);
+      });
+  });
+});


### PR DESCRIPTION
This PR adds an adapter for the YF Link community-governed AMM LINKSWAP.

@cr-igor tagging you following our conversation, for when you're back from holidays and can test/review. Not sure if this is fully correct yet (particularly in tracking governance vault and changes to `1_deploy_registry_and_adapters.js` but hopefully a good start.

Thanks for the support so far and do let me know if this needs any changes!