### PR TITLE
add livepeer staking adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ All the deployed contracts' addresses are available [here](../../wiki/Addresses)
 | [KeeperDAO](./contracts/adapters/keeperDao) | An on-chain liquidity underwriter for DeFi. | [Asset adapter](./contracts/adapters/keeperDao/KeeperDaoAssetAdapter.sol) | ["KToken"](contracts/adapters/keeperDao/KeeperDaoTokenAdapter.sol) |
 | [KIMCHI](contracts/adapters/kimchi) | Farm KIMCHI by staking LP tokens. | [Staking adapter](contracts/adapters/kimchi/KimchiStakingAdapter.sol) | — |
 | [KyberDAO](./contracts/adapters/kyber) | Platform that allows KNC token holders to participate in governance. | [Asset adapter](./contracts/adapters/kyber/KyberAssetAdapter.sol) | — |
-| [Livepeer](./contracts/adapters/livepeer) | Delegated stake based protocol for decentralized video streaming. | [Staking adapter](./contracts/adapters/livepeer/LivepeerStakingAdaptor.sol) | — |
+| [Livepeer](./contracts/adapters/livepeer) | Delegated stake based protocol for decentralized video streaming. | [Staking adapter](./contracts/adapters/livepeer/LivepeerStakingAdapter.sol) | — |
 | [Chai](./contracts/adapters/maker) | A simple ERC20 wrapper over the Dai Savings Protocol. | [Asset adapter](./contracts/adapters/maker/ChaiAdapter.sol) | ["Chai token"](./contracts/adapters/maker/ChaiTokenAdapter.sol) |
 | [Dai Savings Protocol](./contracts/adapters/maker) | Decentralized lending protocol. | [Asset adapter](./contracts/adapters/maker/DSRAdapter.sol) | — |
 | [Maker Governance](./contracts/adapters/maker) | MKR tokens locked on the MakerDAO governance contracts. | [Asset adapter](./contracts/adapters/maker/MakerGovernanceAdapter.sol) | — |

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ All the deployed contracts' addresses are available [here](../../wiki/Addresses)
 | [KeeperDAO](./contracts/adapters/keeperDao) | An on-chain liquidity underwriter for DeFi. | [Asset adapter](./contracts/adapters/keeperDao/KeeperDaoAssetAdapter.sol) | ["KToken"](contracts/adapters/keeperDao/KeeperDaoTokenAdapter.sol) |
 | [KIMCHI](contracts/adapters/kimchi) | Farm KIMCHI by staking LP tokens. | [Staking adapter](contracts/adapters/kimchi/KimchiStakingAdapter.sol) | — |
 | [KyberDAO](./contracts/adapters/kyber) | Platform that allows KNC token holders to participate in governance. | [Asset adapter](./contracts/adapters/kyber/KyberAssetAdapter.sol) | — |
+| [Livepeer](./contracts/adapters/livepeer) | Delegated stake based protocol for decentralized video streaming. | [Staking adapter](./contracts/adapters/livepeer/LivepeerStakingAdaptor.sol) | — |
 | [Chai](./contracts/adapters/maker) | A simple ERC20 wrapper over the Dai Savings Protocol. | [Asset adapter](./contracts/adapters/maker/ChaiAdapter.sol) | ["Chai token"](./contracts/adapters/maker/ChaiTokenAdapter.sol) |
 | [Dai Savings Protocol](./contracts/adapters/maker) | Decentralized lending protocol. | [Asset adapter](./contracts/adapters/maker/DSRAdapter.sol) | — |
 | [Maker Governance](./contracts/adapters/maker) | MKR tokens locked on the MakerDAO governance contracts. | [Asset adapter](./contracts/adapters/maker/MakerGovernanceAdapter.sol) | — |

--- a/contracts/adapters/livepeer/LivepeerStakingAdapter.sol
+++ b/contracts/adapters/livepeer/LivepeerStakingAdapter.sol
@@ -47,12 +47,13 @@ interface RoundsManager {
  * @dev Implementation of ProtocolAdapter interface.
  * @author Igor Sobolev <sobolev@zerion.io>
  */
-contract LivepeerAdapter is ProtocolAdapter {
+contract LivepeerStakingAdapter is ProtocolAdapter {
 
     string public constant override adapterType = "Asset";
 
     string public constant override tokenType = "ERC20";
 
+    address internal constant LPT = 0x58b6a8a3302369daec383334672404ee733ab239;
     address internal constant BONDING_MANAGER = 0x511bc4556d823ae99630ae8de28b9b80df90ea2e;
     address internal constant ROUNDS_MANAGER = 0x3984fc4ceeef1739135476f625d36d6c35c40dc3;
 
@@ -60,8 +61,13 @@ contract LivepeerAdapter is ProtocolAdapter {
      * @return Amount of LPT staked by the given account.
      * @dev Implementation of ProtocolAdapter interface function.
      */
-    function getBalance(address, address account) external view override returns (uint256) {
-        uint256 currentRound = RoundsManager(ROUNDS_MANAGER).currentRound();
-        return BondingManager(BONDING_MANAGER).pendingStake(account, currentRound);
+    function getBalance(address token, address account) external view override returns (uint256) {
+        if (token == LPT) {
+            uint256 currentRound = RoundsManager(ROUNDS_MANAGER).currentRound();
+            return BondingManager(BONDING_MANAGER).pendingStake(account, currentRound);
+        } else {
+            return 0;
+        }
+        
     }
 }

--- a/contracts/adapters/livepeer/LivepeerStakingAdaptor.sol
+++ b/contracts/adapters/livepeer/LivepeerStakingAdaptor.sol
@@ -1,0 +1,67 @@
+// Copyright (C) 2020 Zerion Inc. <https://zerion.io>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.6.5;
+pragma experimental ABIEncoderV2;
+
+import { ERC20 } from "../../ERC20.sol";
+import { ProtocolAdapter } from "../ProtocolAdapter.sol";
+
+
+
+/**
+ * @dev BondingManager contract interface.
+ * Only the functions required for LivepeerStakingAdapter contract are added.
+ * The BondingManager contract is available here
+ * github.com/livepeer/protocol/blob/streamflow/contracts/bonding/BondingManager.sol.
+ */
+interface BondingManager {
+    function pendingStake(address, uint256) public view returns (uint256);
+}
+
+/**
+ * @dev RoundsManager contract interface.
+ * Only the functions required for LivepeerStakingAdapter contract are added.
+ * The RoundsManager contract is available here
+ * github.com/livepeer/protocol/blob/streamflow/contracts/rounds/RoundsManager.sol.
+ */
+interface RoundsManager {
+    function currentRound() public view returns (uint256);
+}
+
+
+/**
+ * @title Adapter for Livepeer protocol.
+ * @dev Implementation of ProtocolAdapter interface.
+ * @author Igor Sobolev <sobolev@zerion.io>
+ */
+contract LivepeerAdapter is ProtocolAdapter {
+
+    string public constant override adapterType = "Asset";
+
+    string public constant override tokenType = "ERC20";
+
+    address internal constant BONDING_MANAGER = 0x511bc4556d823ae99630ae8de28b9b80df90ea2e;
+    address internal constant ROUNDS_MANAGER = 0x3984fc4ceeef1739135476f625d36d6c35c40dc3;
+
+    /**
+     * @return Amount of LPT staked by the given account.
+     * @dev Implementation of ProtocolAdapter interface function.
+     */
+    function getBalance(address, address account) external view override returns (uint256) {
+        uint256 currentRound = RoundsManager(ROUNDS_MANAGER).currentRound();
+        return BondingManager(BONDING_MANAGER).pendingStake(account, currentRound);
+    }
+}

--- a/migrations_scripts/1_deploy_registry_and_add_adapters.js
+++ b/migrations_scripts/1_deploy_registry_and_add_adapters.js
@@ -33,6 +33,7 @@ const IearnAdapter = artifacts.require('IearnAdapter');
 const KeeperDaoAssetAdapter = artifacts.require('KeeperDaoAssetAdapter');
 const KimchiStakingAdapter = artifacts.require('KimchiStakingAdapter');
 const KyberAdapter = artifacts.require('KyberAdapter');
+const LivepeerStakingAdaptor = artifacts.require('LivepeerStakingAdaptor');
 const ChaiAdapter = artifacts.require('ChaiAdapter');
 const DSRAdapter = artifacts.require('DSRAdapter');
 const GovernanceAdapter = artifacts.require('GovernanceAdapter');
@@ -144,6 +145,7 @@ const batAddress = '0x0D8775F648430679A709E98d2b0Cb6250d2887EF';
 const ethAddress = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 const linkAddress = '0x514910771AF9Ca656af840dff83E8264EcF986CA';
 const kncAddress = '0xdd974D5C2e2928deA5F71b9825b8b646686BD200';
+const lptAddress = '0x58b6a8a3302369daec383334672404ee733ab239';
 const repAddress = '0x1985365e9f78359a9B6AD760e32412f4a445E862';
 const mkrAddress = '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2';
 const manaAddress = '0x0F5D2fB29fb7d3CFeE444a200298f468908cC942';
@@ -691,6 +693,9 @@ const kyberAdapterTokens = [
   kncAddress,
   ethAddress,
 ];
+const livepeerAdapterTokens = [
+  lptAddress,
+];
 const dsrAdapterTokens = [
   daiAddress,
 ];
@@ -1167,6 +1172,18 @@ module.exports = async (deployer, network, accounts) => {
     'Platform that allows KNC token holders to participate in governance',
     'kyber.network',
     'protocol-icons.s3.amazonaws.com/kyber.png',
+    '0',
+  ]);
+
+  await deployer.deploy(LivepeerStakingAdaptor, { from: accounts[0] });
+  adapters.push([LivepeerStakingAdapter.address]);
+  tokens.push([livepeerAdapterTokens]);
+  protocolNames.push('Livepeer');
+  metadata.push([
+    'Livepeer',
+    'Delegated stake based protocol for decentralized video streaming.',
+    'livepeer.org',
+    'protocol-icons.s3.amazonaws.com/livepeer.png',
     '0',
   ]);
 

--- a/migrations_scripts/1_deploy_registry_and_add_adapters.js
+++ b/migrations_scripts/1_deploy_registry_and_add_adapters.js
@@ -33,7 +33,7 @@ const IearnAdapter = artifacts.require('IearnAdapter');
 const KeeperDaoAssetAdapter = artifacts.require('KeeperDaoAssetAdapter');
 const KimchiStakingAdapter = artifacts.require('KimchiStakingAdapter');
 const KyberAdapter = artifacts.require('KyberAdapter');
-const LivepeerStakingAdaptor = artifacts.require('LivepeerStakingAdaptor');
+const LivepeerStakingAdapter = artifacts.require('LivepeerStakingAdapter');
 const ChaiAdapter = artifacts.require('ChaiAdapter');
 const DSRAdapter = artifacts.require('DSRAdapter');
 const GovernanceAdapter = artifacts.require('GovernanceAdapter');
@@ -1175,7 +1175,7 @@ module.exports = async (deployer, network, accounts) => {
     '0',
   ]);
 
-  await deployer.deploy(LivepeerStakingAdaptor, { from: accounts[0] });
+  await deployer.deploy(LivepeerStakingAdapter, { from: accounts[0] });
   adapters.push([LivepeerStakingAdapter.address]);
   tokens.push([livepeerAdapterTokens]);
   protocolNames.push('Livepeer');


### PR DESCRIPTION
This PR adds a staking adapter for the Livepeer protocol. Note: the [metadata](https://github.com/zeriontech/defi-sdk/compare/master...adamsoffer:livepeer-adaptor?expand=1#diff-7d6910f4d9b0ea604c8a7575be91ff6fce9083b589736da559e0b11ecaa712c9R1186) references the livepeer logo (`protocol-icons.s3.amazonaws.com/livepeer.png`) which doesn't yet exist in your s3 bucket so someone will have to upload it (attached below).

Thanks! Let me know if this needs any changes.

![livepeer](https://user-images.githubusercontent.com/555740/105760471-d8272100-5f1f-11eb-87c7-09bb767dcd42.png)
